### PR TITLE
[CUSTOMER-406]mysql_migrationsのupの動作を修正

### DIFF
--- a/core_functions.js
+++ b/core_functions.js
@@ -32,26 +32,27 @@ function add_migration(argv, path, cb) {
 }
 
 function up_migrations(container, max_count, path, cb) {
-  queryFunctions.run_query(container, "SELECT timestamp FROM " + table + " ORDER BY timestamp DESC LIMIT 1", function (results) {
+  queryFunctions.run_query(container, "SELECT timestamp FROM " + table + " ORDER BY timestamp ASC", function (results) {
     var file_paths = [];
-    var max_timestamp = 0;
-    if (results.length) {
-      max_timestamp = results[0].timestamp;
-    }
-
-    fileFunctions.readFolder(path, function (files) {
-      files.forEach(function (file) {
+    fileFunctions.readFolder(path, (files) => {
+      for (file of files) {
         var timestamp_split = file.split("_", 1);
-        if (0 === timestamp_split.length) {
+        if (timestamp_split.length) {
+          var timestamp = Number(timestamp_split[0]);
+          if (!(Number.isInteger(timestamp) && timestamp.toString().length == 13)) {
+            throw new Error('Invalid file ' + file);
+          }
+          const ret = results.find(obj => Number(obj.timestamp) === timestamp);
+          if (!ret) {
+            file_paths.push({ timestamp : timestamp, file_path : file});
+          }
+        } else {
           throw new Error('Invalid file ' + file);
         }
-        var timestamp = parseInt(timestamp_split[0]);
-        if (Number.isInteger(timestamp) && timestamp.toString().length == 13 && timestamp > max_timestamp) {
-          file_paths.push({ timestamp : timestamp, file_path : file});
-        }
-      });
+      }
 
       var final_file_paths = file_paths.sort(function(a, b) { return (a.timestamp - b.timestamp)}).slice(0, max_count);
+
       queryFunctions.execute_query(container, path, final_file_paths, 'up', cb);
     });
   });


### PR DESCRIPTION
## 概要
mysql_migrationsのupの動作を修正
[CUSTOMER-406](https://kailash-tech.atlassian.net/browse/CUSTOMER-406)

## テスト項目
- [x] npm test を実行し jshint のワーニングが出ないことを確認した。->(担当箇所内)
- [x] npm run unittestを行いAll Clearであることを確認した。