### PR TITLE
マイグレーションファイルを直接実行できるようにする

### DIFF
--- a/core_functions.js
+++ b/core_functions.js
@@ -97,7 +97,7 @@ function set_migrations(container, timestamp_val, path, cb) {
 
 function run_migration_directly(file, type, container, path, cb) {
   var current_file_path = path + "/" + file;
-  var query = require(current_file_path)[type];
+  var query = require(current_file_path)[type](container);
   queryFunctions.run_query(container, query, cb);
 }
 


### PR DESCRIPTION
## 概要

マイグレーションファイルを直接指定して実行する run オプションが動かなかったので修正しました。

元々の仕様を踏襲していますが、 run でマイグレーションを実行した場合はタイムスタンプが記録されないため、
何度も実行することができるので本番などでの実行は注意が必要かもしれません。

```bash
$ node legal_fw/commands/migration.js run 1555381007015_test.js up
```