### PR TITLE
down_skipオプション追加

### DIFF
--- a/core_functions.js
+++ b/core_functions.js
@@ -84,7 +84,6 @@ function down_migrations(container, max_count, path, cb) {
 
 function down_skip_migrations(container, max_count, path, cb) {
   queryFunctions.run_query(container, "SELECT timestamp FROM " + table + " ORDER BY timestamp DESC LIMIT " + max_count, function (results) {
-    var file_paths = [];
     var max_timestamp = 0;
     if (results.length) {
       var temp_timestamps = results.map(function(ele) {
@@ -101,6 +100,8 @@ function down_skip_migrations(container, max_count, path, cb) {
       queryFunctions.run_query(container, query, function (res) {
         cb();
       });
+    } else {
+      cb();
     }
   });
 }

--- a/core_functions.js
+++ b/core_functions.js
@@ -82,6 +82,29 @@ function down_migrations(container, max_count, path, cb) {
   });
 }
 
+function down_skip_migrations(container, max_count, path, cb) {
+  queryFunctions.run_query(container, "SELECT timestamp FROM " + table + " ORDER BY timestamp DESC LIMIT " + max_count, function (results) {
+    var file_paths = [];
+    var max_timestamp = 0;
+    if (results.length) {
+      var temp_timestamps = results.map(function(ele) {
+        return ele.timestamp;
+      });
+      let strTimestamps = '';
+      temp_timestamps.forEach(function (temp_timestamp) {
+        if(strTimestamps.length > 0) {
+          strTimestamps += ",";
+        }
+        strTimestamps += "'" + temp_timestamp + "'";
+      });
+      let query = "DELETE FROM " + table + " WHERE `timestamp` IN (" + strTimestamps + ")";
+      queryFunctions.run_query(container, query, function (res) {
+        cb();
+      });
+    }
+  });
+}
+
 function set_migrations(container, timestamp_val, path, cb) {
 
   var timestamps = [];
@@ -105,6 +128,7 @@ module.exports = {
   add_migration: add_migration,
   up_migrations: up_migrations,
   down_migrations: down_migrations,
+  down_skip_migrations: down_skip_migrations,
   set_migrations: set_migrations,
   run_migration_directly: run_migration_directly
 };

--- a/core_functions.js
+++ b/core_functions.js
@@ -89,17 +89,7 @@ function down_skip_migrations(container, max_count, path, cb) {
       var temp_timestamps = results.map(function(ele) {
         return ele.timestamp;
       });
-      let strTimestamps = '';
-      temp_timestamps.forEach(function (temp_timestamp) {
-        if(strTimestamps.length > 0) {
-          strTimestamps += ",";
-        }
-        strTimestamps += "'" + temp_timestamp + "'";
-      });
-      let query = "DELETE FROM " + table + " WHERE `timestamp` IN (" + strTimestamps + ")";
-      queryFunctions.run_query(container, query, function (res) {
-        cb();
-      });
+      queryFunctions.updateRecords(container, "down", table, temp_timestamps, cb);
     } else {
       cb();
     }

--- a/index.js
+++ b/index.js
@@ -40,6 +40,14 @@ function handle(argv, container, path, cb) {
       coreFunctions.down_migrations(container, count, path, function () {
         cb();
       });
+    } else if (argv[2] == 'down-skip') {
+      var count = null;
+      if (argv.length > 3) {
+        count = parseInt(argv[3]);
+      } else count = 1;
+      coreFunctions.down_skip_migrations(container, count, path, function () {
+        cb();
+      });
     } else if (argv[2] == 'refresh') {
       coreFunctions.down_migrations(container, 999999, path, function () {
         coreFunctions.up_migrations(container, 999999, path, function () {

--- a/query.js
+++ b/query.js
@@ -68,7 +68,16 @@ function updateRecords(container, type, table, timestamp_val, cb) {
       cb();
     });
   } else if (type == 'down') {
-    query = "DELETE FROM " + table + " WHERE `timestamp` = '" + timestamp_val + "'"
+    let timestampList;
+    if (!Array.isArray(timestamp_val)){
+      timestampList = [timestamp_val];
+    } else {
+      timestampList = timestamp_val;
+    }
+    timestampList = timestampList.map((it) => {
+      return '"' + it + '"';
+    });
+    query = "DELETE FROM " + table + " WHERE `timestamp` in (" + timestampList.join(',') + ")";
 
     run_query(container, query, function (res) {
       cb();


### PR DESCRIPTION
## 概要
・down-skip というのを追加して、down処理をせずにポインタを一つ戻せるように修正
・引数に数値を指定した場合、その数だけもどせるように修正
形式：Wed Apr 03 2019 09:00:00 GMT+0900 
## テスト項目
- [x] 差分に変な修正が含まれてない
- [x] down-skipが正常に動作すること
- [x] down-skip 2が正常に動作すること
- [x] upが正常に動作すること
- [x] downが正常に動作すること