### PR TITLE
SQLを trim してから "@" の判定を行う

### DIFF
--- a/query.js
+++ b/query.js
@@ -8,7 +8,7 @@ function run_query(container, query, cb) {
   if (0 === query.length || !query[0]) {
     return cb();
   }
-  var query_it = query.shift();
+  var query_it = String(query.shift()).trim();
   if (process.env.VERBOSE) {
     console.log(query_it);
   }


### PR DESCRIPTION
## 概要

以下のようにSQLの前後にスペースや改行が含まれている場合、
エラー無視の `@` の判定が動作していなかったので、 trim してから `@` の判定を行うようにします。

```js
return `
@ALTER TABLE \`statistics_punch\` ADD CONSTRAINT \`statistics_punch_ibfk_1\`
FOREIGN KEY (\`office_id\`) REFERENCES \`offices\`(\`id\`) ON DELETE NO ACTION ON UPDATE CASCADE
`;
```

