### PR TITLE
例外をキャッチしてコールバック関数に渡す

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,8 +31,8 @@ function execute(argv, container, path, cb) {
 function handle(argv, container, path, cb) {
   if (argv.length > 2 && argv.length <= 6) {
     if (argv[2] == 'add' && (argv[3] == 'migration' || argv[3] == 'seed')) {
-      coreFunctions.add_migration(argv, path, function () {
-        cb();
+      coreFunctions.add_migration(argv, path, function (err) {
+        cb(err);
       });
     } else if (argv[2] == 'up') {
       var count = null;
@@ -41,42 +41,42 @@ function handle(argv, container, path, cb) {
       } else {
         count = 999999;
       }
-      coreFunctions.up_migrations(container, count, path, function () {
-        cb();
+      coreFunctions.up_migrations(container, count, path, function (err) {
+        cb(err);
       });
     } else if (argv[2] == 'down') {
       var count = null;
       if (argv.length > 3) {
         count = parseInt(argv[3]);
       } else count = 1;
-      coreFunctions.down_migrations(container, count, path, function () {
-        cb();
+      coreFunctions.down_migrations(container, count, path, function (err) {
+        cb(err);
       });
     } else if (argv[2] == 'down-skip') {
       var count = null;
       if (argv.length > 3) {
         count = parseInt(argv[3]);
       } else count = 1;
-      coreFunctions.down_skip_migrations(container, count, path, function () {
-        cb();
+      coreFunctions.down_skip_migrations(container, count, path, function (err) {
+        cb(err);
       });
     } else if (argv[2] == 'refresh') {
       coreFunctions.down_migrations(container, 999999, path, function () {
-        coreFunctions.up_migrations(container, 999999, path, function () {
-          cb();
+        coreFunctions.up_migrations(container, 999999, path, function (err) {
+          cb(err);
         });
       });
     } else if (argv[2] == 'run' && migrations_types.indexOf(argv[4]) > -1) {
-      coreFunctions.run_migration_directly(argv[3], argv[4], container, path, function () {
-        cb();
+      coreFunctions.run_migration_directly(argv[3], argv[4], container, path, function (err) {
+        cb(err);
       });
     } else if (argv[2] == 'set') {
       var timestamp_val = argv[3] || 0;
       if (10 === String(timestamp_val).length) {
         timestamp_val += '000';
       }
-      coreFunctions.set_migrations(container, timestamp_val, path, function () {
-        cb();
+      coreFunctions.set_migrations(container, timestamp_val, path, function (err) {
+        cb(err);
       });
     } else {
       throw new Error('command not found : ' + argv.join(" "));

--- a/query.js
+++ b/query.js
@@ -69,6 +69,8 @@ function execute_query(container, path, final_file_paths, type, cb) {
           execute_query(container, path, final_file_paths, type, cb);
         });
       }
+    }).catch(err => {
+      cb(err);
     });
   } else {
     cb();


### PR DESCRIPTION
## 概要

マイグレーションの実行時に例外が発生した場合に、 catch してコールバック関数に渡すようにします。